### PR TITLE
CASMPET-7672: Only create tpm-intermediate-psp rolebinding if PSP capability exists

### DIFF
--- a/kubernetes/tpm-intermediate/Chart.yaml
+++ b/kubernetes/tpm-intermediate/Chart.yaml
@@ -23,7 +23,7 @@
 #
 apiVersion: v2
 name: tpm-intermediate
-version: 1.0.0
+version: 1.0.1
 description: A Helm chart for Kubernetes
 home: https://github.com/Cray-HPE/tpm-intermediate
 maintainers:

--- a/kubernetes/tpm-intermediate/templates/psp-rolebinding.yaml
+++ b/kubernetes/tpm-intermediate/templates/psp-rolebinding.yaml
@@ -1,7 +1,7 @@
 {{/*
 MIT License
 
-(C) Copyright [2023] Hewlett Packard Enterprise Development LP
+(C) Copyright [2023, 2025] Hewlett Packard Enterprise Development LP
 
 Permission is hereby granted, free of charge, to any person obtaining a
 copy of this software and associated documentation files (the "Software"),
@@ -21,6 +21,7 @@ OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
 ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 OTHER DEALINGS IN THE SOFTWARE.
 */}}
+{{- if .Capabilities.APIVersions.Has "policy/v1beta1/PodSecurityPolicy" }}
 ---
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
@@ -37,3 +38,4 @@ roleRef:
   kind: ClusterRole
   name: restricted-transition-psp
   apiGroup: rbac.authorization.k8s.io
+{{- end }}


### PR DESCRIPTION
## Summary and Scope
CASMPET-7672: Only create tpm-intermediate-psp rolebinding if PSP capability exists

## Testing
Deployed new helm chart on `beau` and `tpm-intermediate-psp` rolebinding not created.

Old chart creates `tpm-intermediate-psp` rolebinding even though PSP capability does not exists with K8s 1.32.
```
pit:~/studenym/tpm-intermediate # helm history -n vault tpm-intermediate
REVISION	UPDATED                 	STATUS  	CHART                 	APP VERSION	DESCRIPTION
1       	Mon Aug 11 15:11:35 2025	deployed	tpm-intermediate-1.0.0	1.0.0      	Install complete
pit:~/studenym/tpm-intermediate # kubectl get rolebinding -n vault | grep tpm
pit:~/studenym/tpm-intermediate # helm rollback -n vault tpm-intermediate 1
Rollback was a success! Happy Helming!
pit:~/studenym/tpm-intermediate # kubectl get rolebinding -n vault | grep tpm
tpm-intermediate-psp           ClusterRole/restricted-transition-psp   3s
```

Upgrade to new chart and `tpm-intermediate-psp` rolebinding is not created ...
```
pit:~/studenym/tpm-intermediate # helm upgrade -n vault tpm-intermediate tpm-intermediate-1.0.1-20250923204553+4f18eba.tgz
Release "tpm-intermediate" has been upgraded. Happy Helming!
NAME: tpm-intermediate
LAST DEPLOYED: Tue Sep 23 21:08:41 2025
NAMESPACE: vault
STATUS: deployed
REVISION: 3
TEST SUITE: None
pit:~/studenym/tpm-intermediate # helm history -n vault tpm-intermediate
REVISION	UPDATED                 	STATUS    	CHART                                        	APP VERSION	DESCRIPTION
1       	Mon Aug 11 15:11:35 2025	superseded	tpm-intermediate-1.0.0                       	1.0.0      	Install complete
2       	Tue Sep 23 21:05:04 2025	superseded	tpm-intermediate-1.0.0                       	1.0.0      	Rollback to 1
3       	Tue Sep 23 21:08:41 2025	deployed  	tpm-intermediate-1.0.1-20250923204553+4f18eba	1.0.0      	Upgrade complete
pit:~/studenym/tpm-intermediate # kubectl get rolebinding -n vault | grep tpm
pit:~/studenym/tpm-intermediate #
```

Rollback to old chart and psp rolebinding is created again.
```
pit:~/studenym/tpm-intermediate # kubectl get rolebinding -n vault | grep tpm
pit:~/studenym/tpm-intermediate # helm rollback -n vault tpm-intermediate 1
Rollback was a success! Happy Helming!
pit:~/studenym/tpm-intermediate # helm history -n vault tpm-intermediate
REVISION	UPDATED                 	STATUS    	CHART                                        	APP VERSION	DESCRIPTION
1       	Mon Aug 11 15:11:35 2025	superseded	tpm-intermediate-1.0.0                       	1.0.0      	Install complete
2       	Tue Sep 23 21:05:04 2025	superseded	tpm-intermediate-1.0.0                       	1.0.0      	Rollback to 1
3       	Tue Sep 23 21:08:41 2025	superseded	tpm-intermediate-1.0.1-20250923204553+4f18eba	1.0.0      	Upgrade complete
4       	Tue Sep 23 21:10:09 2025	deployed  	tpm-intermediate-1.0.0                       	1.0.0      	Rollback to 1
pit:~/studenym/tpm-intermediate # kubectl get rolebinding -n vault | grep tpm
tpm-intermediate-psp           ClusterRole/restricted-transition-psp   13s
pit:~/studenym/tpm-intermediate #
```

## Risks and Mitigations

Low

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

